### PR TITLE
Post m2 fixes

### DIFF
--- a/FlexEngine/src/FlexEngine/Core/imguiwrapper.cpp
+++ b/FlexEngine/src/FlexEngine/Core/imguiwrapper.cpp
@@ -185,7 +185,9 @@ namespace FlexEngine
     CustomImguiStyle();
 
     // load font
-    io.Fonts->AddFontFromFileTTF("..\\FlexEngine\\assets\\fonts\\Noto_Sans\\static\\NotoSans-Regular.ttf", 21.f);
+    std::string currentDir = std::filesystem::current_path().string();
+    std::string fontPath = currentDir + "/assets/fonts/Suez_One/SuezOne-Regular.ttf";
+    io.Fonts->AddFontFromFileTTF(fontPath.c_str(), 21.f);
 
     // setup platform/renderer bindings
     ImGui_ImplGlfw_InitForOpenGL(window->GetGLFWWindow(), true);

--- a/MicroChess/MicroChess.vcxproj
+++ b/MicroChess/MicroChess.vcxproj
@@ -120,6 +120,9 @@
       <AdditionalDependencies>FlexEngine.lib;opengl32.lib;glfw3.lib;ImGuid.lib;fmodstudioL_vc.lib;fmodL_vc.lib;assimp-vc143-mtd.lib;freetyped.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <IgnoreSpecificDefaultLibraries>libcmtd.lib;libcmt.lib;msvcrt.lib</IgnoreSpecificDefaultLibraries>
     </Link>
+    <PostBuildEvent>
+      <Command>xcopy "$(ProjectDir)assets" "$(TargetDir)assets" /E /I /Y</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -139,6 +142,9 @@
       <AdditionalDependencies>FlexEngine.lib;opengl32.lib;glfw3.lib;ImGui.lib;fmodstudio_vc.lib;fmod_vc.lib;assimp-vc143-mt.lib;freetype.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <IgnoreSpecificDefaultLibraries>libcmtd.lib;libcmt.lib;msvcrtd.lib</IgnoreSpecificDefaultLibraries>
     </Link>
+    <PostBuildEvent>
+      <Command>xcopy "$(ProjectDir)assets" "$(TargetDir)assets" /E /I /Y</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <None Include="assets\shaders\batch2.0.frag" />


### PR DESCRIPTION
- This fixes crash due to assets folder not being copied over to x64 folder, causing the exe run from there to crash.
- Fixes crash on game startup due to font file not being found when in x64 folder due to it referencing engine assets, which are not copied over. This has been replaced to a font in the project assets folder for MicroChess.